### PR TITLE
Fix for bug when attempting to Cursor Slice an empty result set

### DIFF
--- a/GraphQL.PreProcessingExtensions/Paging/CursorPaging/CursorPageSlice.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/CursorPaging/CursorPageSlice.cs
@@ -15,7 +15,7 @@ namespace HotChocolate.PreProcessingExtensions.Pagination
     {
         public CursorPageSlice(IEnumerable<ICursorResult<TEntity>> results, int? totalCount, bool hasPreviousPage, bool hasNextPage)
         {
-            this.CursorResults = results ?? Enumerable.Empty<ICursorResult<TEntity>>();
+            this.CursorResults = results ?? throw new ArgumentException(nameof(results));
             this.TotalCount = totalCount;
             this.HasPreviousPage = hasPreviousPage;
             this.HasNextPage = hasNextPage;

--- a/GraphQL.PreProcessingExtensions/Paging/CursorPaging/CursorPageSlice.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/CursorPaging/CursorPageSlice.cs
@@ -15,7 +15,7 @@ namespace HotChocolate.PreProcessingExtensions.Pagination
     {
         public CursorPageSlice(IEnumerable<ICursorResult<TEntity>> results, int? totalCount, bool hasPreviousPage, bool hasNextPage)
         {
-            this.CursorResults = (results ?? throw new ArgumentException(nameof(results))).ToList();
+            this.CursorResults = results ?? Enumerable.Empty<ICursorResult<TEntity>>();
             this.TotalCount = totalCount;
             this.HasPreviousPage = hasPreviousPage;
             this.HasNextPage = hasNextPage;

--- a/GraphQL.PreProcessingExtensions/Paging/CursorPaging/IEnumerableCursorPagingCustomExtensions.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/CursorPaging/IEnumerableCursorPagingCustomExtensions.cs
@@ -42,7 +42,7 @@ namespace HotChocolate.PreProcessingExtensions
         {
             //Do nothing if there are no results...
             if (!items.Any())
-                return new CursorPageSlice<T>(null, 0, false, false);
+                return new CursorPageSlice<T>(Enumerable.Empty<ICursorResult<T>>(), 0, false, false);
 
             var afterIndex = after != null
                 ? IndexEdge<string>.DeserializeCursor(after)

--- a/GraphQL.PreProcessingExtensions/Paging/OffsetPaging/IEnumerableOffsetPagingCustomExtensions.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/OffsetPaging/IEnumerableOffsetPagingCustomExtensions.cs
@@ -44,7 +44,7 @@ namespace HotChocolate.PreProcessingExtensions
         {
             //Do nothing if there are no results...
             if (!items.Any())
-                return new OffsetPageResults<T>(new List<T>(), false, false, 0);
+                return new OffsetPageResults<T>(Enumerable.Empty<T>(), false, false, 0);
 
             //NOTE: Implemented similar algorithm that would be used in a SQL Query; also similar to what the default
             //      HotChocolate QueryableCursorPagingHandler does...


### PR DESCRIPTION
When no results are returned by an underlying data source (e.g. empty list/table, etc) **IEnumerableCursorPagingCustomExtensions.SliceAsCursorPage()** creates a new **CursorPageSlice<T>** and passes null for the **results** parameter. This causes an **ArgumentException** to be thrown by the CursorPageSlice constructor. 

This bug was discovered when testing a resolver over a postgresql table I had just created but contained no rows.
The GraphQL query should return an empty node collection and totalCount = 0.

Relevant line for the bug:

https://github.com/cajuncoding/GraphQL.RepoDB/blob/52dabefdeec5f6d29e4f97c3a927bc05426ac31c/GraphQL.PreProcessingExtensions/Paging/CursorPaging/IEnumerableCursorPagingCustomExtensions.cs#L45

This can be reproduced by modifying **Tests.StarWarsCharacterResolver.CreateCharacters** to return an empty list and running the **TestParamsContextCursorPagingOnlyFirst** test.

This PR modifies behavior this by:

- Avoid throwing ArgumentException in CursorPageSlice<T> to match the way Offset pagination handles empty results.
- Swapped from creating a new List<T> to Enumerable.Empty<T>() to avoid un-needed allocation.