### PR TITLE
Feature/add net6.0 build target support and update to hc v12.4.1

### DIFF
--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL.PreProcessingExtensions.Tests.csproj
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL.PreProcessingExtensions.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL.PreProcessingExtensions.Tests.csproj
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL.PreProcessingExtensions.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="12.0.1" />
-    <PackageReference Include="HotChocolate.Data" Version="12.0.1" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.4.1" />
+    <PackageReference Include="HotChocolate.Data" Version="12.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />

--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterRepo.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterRepo.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using HotChocolate.PreProcessingExtensions.Tests;
+
+namespace HotChocolate.PreProcessingExtensions.Tests
+{
+    internal class StarWarsCharacterRepo
+    {
+        public static IEnumerable<IStarWarsCharacter> CreateCharacters()
+        {
+            yield return new StarWarsHuman
+            (
+                1000,
+                "Luke Skywalker",
+                "Tatooine",
+                new int[] {2000, 2001}
+            );
+
+            yield return new StarWarsHuman
+            (
+                1001,
+                "Darth Vader",
+                "Tatooine"
+            );
+
+            yield return new StarWarsHuman
+            (
+                1002,
+                "Han Solo"
+            );
+
+            yield return new StarWarsHuman
+            (
+                1003,
+                "Leia Organa",
+                "Alderaan",
+                new int[] { 2000, 2001 }
+            );
+
+            yield return new StarWarsHuman
+            (
+                1004,
+                "Wilhuff Tarkin"
+            );
+
+            yield return new StarWarsDroid
+            (
+                2000,
+                "C-3PO",
+                "Protocol"
+            );
+
+            yield return new StarWarsDroid
+            (
+                2001,
+                "R2-D2",
+                "Astromech"
+            );
+        }
+    }
+}

--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterResolver.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterResolver.cs
@@ -50,7 +50,7 @@ namespace HotChocolate.PreProcessingExtensions.Tests
                 ? Enumerable.Empty<IStarWarsCharacter>()
                 : CreateCharacters();
 
-            var results = characters.SliceAsOffsetPage(paramsContext.OffsetPagingArgs ?? );
+            var results = characters.SliceAsOffsetPage(paramsContext.OffsetPagingArgs);
 
             return Task.FromResult(results.AsPreProcessedPageResults());
         }

--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterResolver.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterResolver.cs
@@ -17,7 +17,7 @@ namespace HotChocolate.PreProcessingExtensions.Tests
         [GraphQLName("starWarsCharacters")]
         public Task<IEnumerable<IStarWarsCharacter>> GetStarWarsCharactersAsync()
         {
-            var results = CreateCharacters();
+            var results = StarWarsCharacterRepo.CreateCharacters();
             return Task.FromResult(results);
         }
 
@@ -31,7 +31,7 @@ namespace HotChocolate.PreProcessingExtensions.Tests
         {
             var characters = testEmptyResults
                 ? Enumerable.Empty<IStarWarsCharacter>()
-                : CreateCharacters();
+                : StarWarsCharacterRepo.CreateCharacters();
             
             var results = characters.SliceAsCursorPage(paramsContext.CursorPagingArgs);
             
@@ -48,61 +48,11 @@ namespace HotChocolate.PreProcessingExtensions.Tests
         {
             var characters = testEmptyResults
                 ? Enumerable.Empty<IStarWarsCharacter>()
-                : CreateCharacters();
+                : StarWarsCharacterRepo.CreateCharacters();
 
             var results = characters.SliceAsOffsetPage(paramsContext.OffsetPagingArgs);
 
             return Task.FromResult(results.AsPreProcessedPageResults());
-        }
-
-        private static IEnumerable<IStarWarsCharacter> CreateCharacters()
-        {
-            yield return new StarWarsHuman
-            (
-                1000,
-                "Luke Skywalker",
-                "Tatooine"
-            );
-
-            yield return new StarWarsHuman
-            (
-                1001,
-                "Darth Vader",
-                "Tatooine"
-            );
-
-            yield return new StarWarsHuman
-            (
-                1002,
-                "Han Solo"
-            );
-
-            yield return new StarWarsHuman
-            (
-                1003,
-                "Leia Organa",
-                "Alderaan"
-            );
-
-            yield return new StarWarsHuman
-            (
-                1004,
-                "Wilhuff Tarkin"
-            );
-
-            yield return new StarWarsDroid
-            (
-                2000,
-                "C-3PO",
-                "Protocol"
-            );
-
-            yield return new StarWarsDroid
-            (
-                2001,
-                "R2-D2",
-                "Astromech"
-            );
         }
     }
 }

--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterResolver.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsCharacterResolver.cs
@@ -50,7 +50,7 @@ namespace HotChocolate.PreProcessingExtensions.Tests
                 ? Enumerable.Empty<IStarWarsCharacter>()
                 : CreateCharacters();
 
-            var results = characters.SliceAsOffsetPage(paramsContext.OffsetPagingArgs);
+            var results = characters.SliceAsOffsetPage(paramsContext.OffsetPagingArgs ?? );
 
             return Task.FromResult(results.AsPreProcessedPageResults());
         }

--- a/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsHuman.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/GraphQL/StarWarsHuman.cs
@@ -1,6 +1,7 @@
 //NOTE: Updated to alleviate Visual Studio warning...
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using HotChocolate.PreProcessingExtensions.Tests;
 using HotChocolate.Types;
@@ -16,11 +17,14 @@ namespace HotChocolate.PreProcessingExtensions.Tests
         public StarWarsHuman(
             int id, 
             string name, 
-            string? homePlanet = null)
+            string? homePlanet = null,
+            int[]? droidIds = null
+        )
         {
             Id = id;
             Name = name;
             HomePlanet = homePlanet;
+            DroidIds = droidIds ?? Array.Empty<int>();
         }
 
         /// <inheritdoc />
@@ -28,6 +32,10 @@ namespace HotChocolate.PreProcessingExtensions.Tests
 
         /// <inheritdoc />
         public string Name { get; }
+
+        /// <inheritdoc />
+        [GraphQLIgnore]
+        public int[] DroidIds { get; }
 
         /// <summary>
         /// The planet the character is originally from.

--- a/GraphQL.PreProcessingExtensions.Tests/TestServers/GraphQLStarWarsTestServer.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/TestServers/GraphQLStarWarsTestServer.cs
@@ -1,17 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using HotChocolate;
-using HotChocolate.AspNetCore.Extensions;
-using HotChocolate.AspNetCore.Serialization;
-using HotChocolate.Execution.Configuration;
-using HotChocolate.PreProcessingExtensions;
 using HotChocolate.PreProcessingExtensions.Tests.GraphQL;
-using HotChocolate.Resolvers;
 using HotChocolate.Types.Pagination;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using StarWars.Characters;
 
 namespace HotChocolate.PreProcessingExtensions.Tests
 {
@@ -32,6 +23,7 @@ namespace HotChocolate.PreProcessingExtensions.Tests
                         .AddType<StarWarsCharacterResolver>()
                         .AddType<StarWarsHuman>()
                         .AddType<StarWarsDroid>()
+                        .AddTypeExtension<HumanFieldResolvers>()
                         .SetPagingOptions(new PagingOptions()
                         {
                             DefaultPageSize = 5,

--- a/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextArgumentsTests.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextArgumentsTests.cs
@@ -92,9 +92,9 @@ namespace HotChocolate.PreProcessingExtensions.Tests
 
             var paramsContext = server.GetParamsContext("starWarsCharacters");
             Assert.IsNotNull(paramsContext?.AllArguments);
-            Assert.AreEqual(paramsContext.AllArguments.Count, 1);
+            Assert.AreEqual(1, paramsContext.AllArguments.Count);
             Assert.IsNotNull(paramsContext?.AllArguments[0]);
-            Assert.AreEqual(paramsContext.AllArguments[0].Name, "order");
+            Assert.AreEqual("order", paramsContext.AllArguments[0].Name);
             Assert.IsNotNull(paramsContext?.AllArguments[0].Value);
         }
     }

--- a/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextPagingTests.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextPagingTests.cs
@@ -208,17 +208,17 @@ namespace HotChocolate.PreProcessingExtensions.Tests
             var offsetPagingParams = paramsContext.OffsetPagingArgs;
 
             Assert.IsNotNull(offsetPagingParams);
-            Assert.AreEqual(2, offsetPagingParams.Skip);
-            Assert.AreEqual(2, offsetPagingParams.Take);
+            Assert.AreEqual(null, offsetPagingParams.Skip);
+            Assert.AreEqual(null, offsetPagingParams.Take);
 
             var resultsJson = (JObject)result.Data[queryKey];
             Assert.IsNotNull(resultsJson);
             var results = resultsJson[SelectionNodeName.Items];
 
             Assert.IsNotNull(results);
-            Assert.AreEqual(2, results.Count());
-            Assert.AreEqual("Han Solo", results.FirstOrDefault()?["name"]);
-            Assert.AreEqual("Leia Organa", results.LastOrDefault()?["name"]);
+            Assert.AreEqual(0, results.Count());
+            //Assert.AreEqual("Han Solo", results.FirstOrDefault()?["name"]);
+            //Assert.AreEqual("Leia Organa", results.LastOrDefault()?["name"]);
         }
 
         #endregion

--- a/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextPagingTests.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextPagingTests.cs
@@ -184,6 +184,43 @@ namespace HotChocolate.PreProcessingExtensions.Tests
             Assert.AreEqual(0, results.Count());
         }
 
+        [TestMethod]
+        public async Task TestParamsContextOffsetPagingDefaultSkipTakeParams()
+        {
+            // arrange
+            var server = CreateStarWarsTestServer();
+
+            // act
+            var result = await server.PostQueryAsync(@"{
+                starWarsCharactersOffsetPaginated() {
+                    items {
+                        id
+                        name
+                    }
+                }
+            }");
+
+            // assert
+            Assert.IsNotNull(result?.Data, "Query Execution Failed");
+
+            var queryKey = "starWarsCharactersOffsetPaginated";
+            var paramsContext = server.GetParamsContext(queryKey);
+            var offsetPagingParams = paramsContext.OffsetPagingArgs;
+
+            Assert.IsNotNull(offsetPagingParams);
+            Assert.AreEqual(2, offsetPagingParams.Skip);
+            Assert.AreEqual(2, offsetPagingParams.Take);
+
+            var resultsJson = (JObject)result.Data[queryKey];
+            Assert.IsNotNull(resultsJson);
+            var results = resultsJson[SelectionNodeName.Items];
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(2, results.Count());
+            Assert.AreEqual("Han Solo", results.FirstOrDefault()?["name"]);
+            Assert.AreEqual("Leia Organa", results.LastOrDefault()?["name"]);
+        }
+
         #endregion
     }
 }

--- a/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextSelectionTests.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextSelectionTests.cs
@@ -189,6 +189,38 @@ namespace HotChocolate.PreProcessingExtensions.Tests
             Assert.AreEqual("name", selectionNames.LastOrDefault());
         }
 
+        [TestMethod]
+        public async Task TestParamsContextDependencySelectionForId()
+        {
+            // arrange
+            var server = CreateStarWarsTestServer();
 
+            // act
+            var result = await server.PostQueryAsync(@"{
+            starWarsCharacters(order: {name: ASC}) {
+                    name
+                    ... on StarWarsHuman {                    
+                        droids {
+                            name
+                            primaryFunction
+                        }
+                    }
+                }
+            }");
+
+            // assert
+            Assert.IsNotNull(result?.Data, "Query Execution Failed");
+
+            var paramsContext = server.GetParamsContext("droids");
+            Assert.IsNotNull(paramsContext?.SelectionDependencies);
+            Assert.AreEqual(1, paramsContext.SelectionDependencies.Count);
+            Assert.AreEqual(nameof(IStarWarsCharacter.Id), paramsContext.SelectionDependencies[0].DependencyMemberName);
+
+            Assert.IsNotNull(paramsContext?.AllSelectionNames);
+            Assert.AreEqual(3, paramsContext.AllSelectionNames.Count);
+            Assert.AreEqual("name", paramsContext.AllSelectionNames[0]);
+            Assert.AreEqual("primaryFunction", paramsContext.AllSelectionNames[1]);
+            Assert.AreEqual("id", paramsContext.AllSelectionNames[2]);
+        }
     }
 }

--- a/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextSelectionTests.cs
+++ b/GraphQL.PreProcessingExtensions.Tests/UnitTests/ParamsContextSelectionTests.cs
@@ -211,16 +211,15 @@ namespace HotChocolate.PreProcessingExtensions.Tests
             // assert
             Assert.IsNotNull(result?.Data, "Query Execution Failed");
 
-            var paramsContext = server.GetParamsContext("droids");
+            var paramsContext = server.GetParamsContext("starWarsCharacters");
             Assert.IsNotNull(paramsContext?.SelectionDependencies);
             Assert.AreEqual(1, paramsContext.SelectionDependencies.Count);
             Assert.AreEqual(nameof(IStarWarsCharacter.Id), paramsContext.SelectionDependencies[0].DependencyMemberName);
 
             Assert.IsNotNull(paramsContext?.AllSelectionNames);
-            Assert.AreEqual(3, paramsContext.AllSelectionNames.Count);
+            Assert.AreEqual(2, paramsContext.AllSelectionNames.Count);
             Assert.AreEqual("name", paramsContext.AllSelectionNames[0]);
-            Assert.AreEqual("primaryFunction", paramsContext.AllSelectionNames[1]);
-            Assert.AreEqual("id", paramsContext.AllSelectionNames[2]);
+            Assert.AreEqual("droids", paramsContext.AllSelectionNames[1]);
         }
     }
 }

--- a/GraphQL.PreProcessingExtensions/GraphQL.PreProcessingExtensions.csproj
+++ b/GraphQL.PreProcessingExtensions/GraphQL.PreProcessingExtensions.csproj
@@ -42,8 +42,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.Data" Version="12.0.1" />
-    <PackageReference Include="HotChocolate.Types.OffsetPagination" Version="12.0.1" />
+    <PackageReference Include="HotChocolate.Data" Version="12.4.1" />
+    <PackageReference Include="HotChocolate.Types.OffsetPagination" Version="12.4.1" />
   </ItemGroup>
 
 </Project>

--- a/GraphQL.PreProcessingExtensions/GraphQL.PreProcessingExtensions.csproj
+++ b/GraphQL.PreProcessingExtensions/GraphQL.PreProcessingExtensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>12.0.1.1</Version>
+    <Version>12.1.4.0</Version>
     <Authors>BBernard / CajunCoding</Authors>
     <Company>CajunCoding</Company>
     <Description>A set of extensions for working with HotChocolate GraphQL and Database access with micro-orms such as RepoDb (or Dapper).  This extension pack provides access to key elements such as Selections/Projections, Sort arguments, &amp; Paging arguments in a significantly simplified facade so this logic can be leveraged in the Resolvers (and lower level Serivces/Repositories that encapsulate all data access) without dependency on IQueryable deferred execution (e.g. EntityFramework).</Description>
@@ -10,31 +10,35 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/cajuncoding/GraphQL.RepoDb</PackageProjectUrl>
     <RepositoryUrl>https://github.com/cajuncoding/GraphQL.RepoDb</RepositoryUrl>
-    <PackageReleaseNotes>Fixed issue #8 related to the in-memory Cursor Paging custom extension handling of empty enumerable results.
+    <PackageReleaseNotes>Release Notes:
+	    - Updated to latest version of HC to v12.4.1
+	    - Fixed breaking change in HC where Field Definition context data methods were removed; now uses the new pattern that HC Core attributes (e.g. UsePaging, UseSorting).
+        - Updated Demo projects to .Net 6.0 and Azure Functions v4.
+	    - Fixed issue #8 related to the in-memory Cursor Paging custom extension handling of empty enumerable results.
 
-      Prior Releases Notes:
-      - Upgraded to now support HotChocolate version 12 with v12.0.1 and synced Nuget Version
-      - Bump HotChocolate version to v11.3.8 (latest v11 version before jumping to v12) and synced Nuget Version
-      - Bump HotChocolate version to v11.2.2 stable and sync Nuget version.
-      - Minor code cleanup and optimizations and removed duplicated validation.
-      - Eliminated dependency on Total Count to compute HasNextPage; this enalbed optimizing the paging algorthims in RepoDB (and other consuming libraries).
-      - Eliminate dependency on Generic Class type constraint for Paging as this is not a restriction of the HC Core, now primitive return types are supported.
-      - Enabled OffsetPaging parameters to be completely optional and default to retrieving all results, unless manually enforced by the Resolver or PagingMiddleware via PagingHandler (which is where HC core implements existing validation).
-      - Add full support for Offset Paging in addition to CursorPaging; including Offset Paging models, extension methods to convert IEnumerable, etc.
-      - Added examples in the StarWars Azure Functions project using in-memory processing (RepoDb implementation is not complete).
-      - Added support to easily determine if TotalCount is selected (as it's a special case selection) to support potential performance optimizations within Resolver logic.
-      - Added more Unit test coverage for Selections, and Paging implmentations
-      - Bump version to HotChocolate v11.0.4.
-      - Add support for Argument Names, and AllArguments facade for easier detecting and working with Arguments.
-      - Add .ConfigureAwait(false) to all awaits for performance.
-      - Fix Namespace consistency (might be a breaking change due to some mixed naming)
-      - Fixed new issue due to changes in Sort arguments in HotChocolate core; sort arguments are resolved correctly again.
-      - Bump to HotChocolate v11.0.1 which now resolves a bug that we helped identify with interfaces in the initial release of v11.0.0.
-      - Provide ability to trace log out some details for the query, execution time, etc. Also improves support for cancellation token throughout DB calls and minor optimizations and cleanup.
+		Prior Releases Notes:
+		- Upgraded to now support HotChocolate version 12 with v12.0.1 and synced Nuget Version
+		- Bump HotChocolate version to v11.3.8 (latest v11 version before jumping to v12) and synced Nuget Version
+		- Bump HotChocolate version to v11.2.2 stable and sync Nuget version.
+		- Minor code cleanup and optimizations and removed duplicated validation.
+		- Eliminated dependency on Total Count to compute HasNextPage; this enalbed optimizing the paging algorthims in RepoDB (and other consuming libraries).
+		- Eliminate dependency on Generic Class type constraint for Paging as this is not a restriction of the HC Core, now primitive return types are supported.
+		- Enabled OffsetPaging parameters to be completely optional and default to retrieving all results, unless manually enforced by the Resolver or PagingMiddleware via PagingHandler (which is where HC core implements existing validation).
+		- Add full support for Offset Paging in addition to CursorPaging; including Offset Paging models, extension methods to convert IEnumerable, etc.
+		- Added examples in the StarWars Azure Functions project using in-memory processing (RepoDb implementation is not complete).
+		- Added support to easily determine if TotalCount is selected (as it's a special case selection) to support potential performance optimizations within Resolver logic.
+		- Added more Unit test coverage for Selections, and Paging implmentations
+		- Bump version to HotChocolate v11.0.4.
+		- Add support for Argument Names, and AllArguments facade for easier detecting and working with Arguments.
+		- Add .ConfigureAwait(false) to all awaits for performance.
+		- Fix Namespace consistency (might be a breaking change due to some mixed naming)
+		- Fixed new issue due to changes in Sort arguments in HotChocolate core; sort arguments are resolved correctly again.
+		- Bump to HotChocolate v11.0.1 which now resolves a bug that we helped identify with interfaces in the initial release of v11.0.0.
+		- Provide ability to trace log out some details for the query, execution time, etc. Also improves support for cancellation token throughout DB calls and minor optimizations and cleanup.
     </PackageReleaseNotes>
     <PackageTags>graphql, graph-ql, hotchocolate, azure, repository, service, repodb, dapper, petapoco, sqlkata, sorting, paging, cursor</PackageTags>
-    <AssemblyVersion>12.0.1.1</AssemblyVersion>
-    <FileVersion>12.0.1.1</FileVersion>
+    <AssemblyVersion>12.1.4.0</AssemblyVersion>
+    <FileVersion>12.1.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GraphQL.PreProcessingExtensions/GraphQLParamsContext/GraphQLParamsContext.cs
+++ b/GraphQL.PreProcessingExtensions/GraphQLParamsContext/GraphQLParamsContext.cs
@@ -158,9 +158,9 @@ namespace HotChocolate.PreProcessingExtensions
             foreach (var selectionField in AllSelectionFields)
             {
                 var contextData = selectionField?.GraphQLFieldSelection?.Field?.ContextData;
-                if (contextData?.ContainsKey(PreProcessingParentDependencies.ContextDataKey) == true)
+                if (contextData?.ContainsKey(PreProcessingParentDependencies.ContextDataKey) == true
+                    && contextData[PreProcessingParentDependencies.ContextDataKey] is IEnumerable<PreProcessingDependencyLink> dependencyLinks)
                 {
-                    var dependencyLinks = (IEnumerable<PreProcessingDependencyLink>)contextData[PreProcessingParentDependencies.ContextDataKey];
                     results.AddRange(dependencyLinks);
                 }
             }

--- a/GraphQL.PreProcessingExtensions/GraphQLParamsContext/ParentProjectionDependencies/PreProcessingParentDependenciesAttribute.cs
+++ b/GraphQL.PreProcessingExtensions/GraphQLParamsContext/ParentProjectionDependencies/PreProcessingParentDependenciesAttribute.cs
@@ -5,7 +5,7 @@ using HotChocolate.Types.Descriptors;
 namespace HotChocolate.PreProcessingExtensions
 {
     /// <summary>
-    /// Custom Attribute for "Pure Code First" configiration of Parent Selection/Projection
+    /// Custom Attribute for "Pure Code First" configuration of Parent Selection/Projection
     /// dependencies for child resolver methods. By specifying Selection names here
     /// we make it easy for the GraphQLParamsContext to resolve dependent Selection field
     /// names dynamically.
@@ -23,10 +23,7 @@ namespace HotChocolate.PreProcessingExtensions
         public override void OnConfigure(IDescriptorContext context, IObjectFieldDescriptor descriptor, MemberInfo member)
         {
             //Dynamically pipe the specified Dependencies into the custom ContextData for this Field!
-            descriptor.ConfigureContextData(c =>
-            {
-                c.AddPreProcessingParentProjectionDependencies(this.SelectionDependencies);   
-            });
+            descriptor.AddPreProcessingParentProjectionDependencies(this.SelectionDependencies);
         }
     }
 

--- a/GraphQL.PreProcessingExtensions/Paging/Common/PagingHelpers.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/Common/PagingHelpers.cs
@@ -5,18 +5,20 @@ namespace GraphQL.PreProcessingExtensions.Paging
 {
     public static class PagingHelpers
     {
+        private static readonly PagingOptions _hcDefaultPagingOptions = new PagingOptions()
+        {
+            DefaultPageSize = PagingDefaults.DefaultPageSize,
+            IncludeTotalCount = PagingDefaults.IncludeTotalCount,
+            MaxPageSize = PagingDefaults.MaxPageSize
+        };
+
         /// <summary>
         /// Simplified helper to get the initialize a PagingOptions with all Default values from HC existing constants.
         /// </summary>
         /// <returns></returns>
         public static PagingOptions GetDefaultPagingOptions()
         {
-            return new PagingOptions()
-            {
-                DefaultPageSize = PagingDefaults.DefaultPageSize,
-                IncludeTotalCount = PagingDefaults.IncludeTotalCount,
-                MaxPageSize = PagingDefaults.MaxPageSize
-            };
+            return _hcDefaultPagingOptions;
         }
 
         /// <summary>

--- a/GraphQL.PreProcessingExtensions/Paging/CursorPaging/IResolverContextCursorPagingExtensions.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/CursorPaging/IResolverContextCursorPagingExtensions.cs
@@ -13,7 +13,7 @@ namespace HotChocolate.PreProcessingExtensions.Pagination
         /// <summary>
         /// Safely process the GraphQL context to retrieve the Cursor Paging arguments;
         /// matches the default names used by HotChocolate Paging middleware (first: int, after: "", last: int, before: "").
-        /// Will return null if the order arguments/info is not available.
+        /// Will return null property values for any arguments/param that is not available in the query.
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>

--- a/GraphQL.PreProcessingExtensions/Paging/OffsetPaging/IResolverContextOffsetPagingExtensions.cs
+++ b/GraphQL.PreProcessingExtensions/Paging/OffsetPaging/IResolverContextOffsetPagingExtensions.cs
@@ -3,6 +3,7 @@
 using HotChocolate.Resolvers;
 using HotChocolate.Types.Pagination;
 using System;
+using GraphQL.PreProcessingExtensions.Paging;
 using HotChocolate.PreProcessingExtensions.Arguments;
 
 
@@ -11,20 +12,25 @@ namespace HotChocolate.PreProcessingExtensions.Pagination
     public static class IResolverContextOffsetPagingExtensions
     {
         /// <summary>
-        /// Safely process the GraphQL context to retrieve the Cursor Paging arguments;
-        /// matches the default names used by HotChocolate Paging middleware (first: int, after: "", last: int, before: "").
-        /// Will return null if the order arguments/info is not available.
+        /// Safely process the GraphQL context to retrieve the Offset Paging arguments;
+        /// matches the default names used by HotChocolate Paging middleware (skip: int, take: int).
+        /// Will return null property values for any arguments/param that is not available in the query
+        ///
+        /// NOTE: As of 11/15/2021 this is now consistent with the behavior of CursorPaging and makes it easier
+        ///         to control default values within your resolvers (e.g. via null coalesce operators).
         /// </summary>
         /// <param name="context"></param>
+        /// <param name="defaultSkip"></param>
+        /// <param name="defaultTake"></param>
         /// <returns></returns>
-        public static OffsetPagingArguments GetOffsetPagingArgsSafely(this IResolverContext context)
+        public static OffsetPagingArguments GetOffsetPagingArgsSafely(this IResolverContext context, int? defaultSkip = null, int? defaultTake = null)
         {
             int? skip = context?.ArgumentValueSafely<int?>(OffsetPagingArgNames.Skip);
             int? take = context?.ArgumentValueSafely<int?>(OffsetPagingArgNames.Take);
 
             //Initialize with default values that enable default behaviour to retrieve all results anytime
             //  the values are not specified; consistent with Cursor based paging where all params are optional.
-            var pagingArgs = new OffsetPagingArguments(skip ?? 0, take ?? int.MaxValue);
+            var pagingArgs = new OffsetPagingArguments(skip ?? defaultSkip, take ?? defaultTake);
 
             return pagingArgs;
         }

--- a/GraphQL.PreProcessingExtensions/README.md
+++ b/GraphQL.PreProcessingExtensions/README.md
@@ -1,5 +1,5 @@
 ﻿## Overview 
-*HotChocolate v11 Extension Pack for working with Micro-ORM(s) and encapsulated data access (instead of IQueryable).*
+*HotChocolate v11/v12 Extension Pack for working with Micro-ORM(s) and encapsulated data access (instead of IQueryable).*
 
 This library greatly simplifies working with HotChocolate to **_pre-processes_** data for
 selecting/projecting, sorting, paging, etc. before returning the data to HotChocolate from the resolver; 
@@ -52,9 +52,14 @@ NuGet package to your project and wire up your Starup  middleware and inject / i
 1. TODO: Enforce HotChocolate configuration defaults for DefaultPageSize in RepoDB... (MaxPageSize is already enforced by HC core default Paging Handlers).
    - This requires a change in HC Core to allow methods to be customized that are currently *not virtual* on the default Paging Handlers.
    - For now, an overload that does not resolve Null/Missing param values, and/or takes in Defaults to be used instead, can be used to specify your own fallback defaults for Offset or Cursor Paging... You can then store your default wherever you like (e.g. Constants).
-1. TODO: Update Implementation summary detais below in README...
 
-### Completed:
+### Release Notes v12.4.1.0:
+- Updated to latest version of HC v12.4.1 stable
+- Fixed breaking change in HC where Field Definition context data methods were removed; now uses the new pattern that HC Core attributes (e.g. UsePaging, UseSorting).
+- Updated Demo projects to .Net 6.0 and Azure Functions v4.
+- Bump RepoDB (Sql Server) version to v1.1.4 stable
+
+### Prior Release Notes:
 1. Added full support for Offset Paging as well as CursorPaging with matching capabilities - including models, extension methods to convert from IEnumerable, etc.
    - Added examples in the StarWars Azure Functions project using in-memory processing (RepoDB Sql Server implementation is also complete).
 1. Added support to easily determine if TotalCount is selected (as it's a special case selection) to support potential performance optimizations within Resolver logic.

--- a/GraphQL.PreProcessingExtensions/README.md
+++ b/GraphQL.PreProcessingExtensions/README.md
@@ -50,7 +50,8 @@ NuGet package to your project and wire up your Starup  middleware and inject / i
 
 ### Pending:
 1. TODO: Enforce HotChocolate configuration defaults for DefaultPageSize in RepoDB... (MaxPageSize is already enforced by HC core default Paging Handlers).
-   - This requires a change in HC Core to allow methods to be customized that are currently *not virtual* on the default Paging Handlers. 
+   - This requires a change in HC Core to allow methods to be customized that are currently *not virtual* on the default Paging Handlers.
+   - For now, an overload that does not resolve Null/Missing param values, and/or takes in Defaults to be used instead, can be used to specify your own fallback defaults for Offset or Cursor Paging... You can then store your default wherever you like (e.g. Constants).
 1. TODO: Update Implementation summary detais below in README...
 
 ### Completed:

--- a/GraphQL.PreProcessingExtensions/README.md
+++ b/GraphQL.PreProcessingExtensions/README.md
@@ -306,19 +306,16 @@ public class HumanType : ObjectType<Human>
         descriptor.Name("human");
         descriptor.Field(t => t.Name).Type<NonNullType<StringType>>();
         descriptor.Field(t => t.Friends).Name("friends")
-            .ConfigureContextData(d =>
-            {
-                //Manually define a Selection/Projection dependency on the "Id" field of
-                //  the parent entity so that it is always provided to the parent resolver.
-                //This helps ensure that the value is not null in our resolver anytime "friends"
-                //  is part of the selection, and the parent "Id" field is not.
-                d.AddPreProcessingParentProjectionDependencies(nameof(Human.Id));
-            })
+            //Manually define a Selection/Projection dependency on the "Id" field of
+            //  the parent entity so that it is always provided to the parent resolver.
+            //This helps ensure that the value is not null in our resolver anytime "friends"
+            //  is part of the selection, and the parent "Id" field is not.
+            .AddPreProcessingParentProjectionDependencies(nameof(Human.Id))
             .Resolver(ctx =>
             {
                 var repository = ctx.Service<IRepository>();
                 var parentHumanId = ctx.Parent<Human>().Id;
-                return repository.GetHuman();
+                return repository.GetRelatedHumans(parentHumanId);
             });
     }
 }

--- a/GraphQL.RepoDb.SqlServer/GraphQL.RepoDb.SqlServer.csproj
+++ b/GraphQL.RepoDb.SqlServer/GraphQL.RepoDb.SqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>12.0.1.0</Version>
+    <Version>12.1.4.0</Version>
     <Authors>BBernard / CajunCoding</Authors>
     <Company>CajunCoding</Company>
     <Description>A set of extensions for working with HotChocolate GraphQL and RepoDb as the data access micro-orm without dependency on IQueryable.  This enables fully encapsulated control over SQL queries in every way within a Service or Repository layer of your application. This extension pack provides a significantly simplified facade to access critial elements such as Selections/Projections, Sort arguments, &amp; Paging arguments with support for mapping them to Models using built in RepoDb functionality.  It also leverages RepoDb to provide a generic, Relay spec compatible, cursor pagination/slice query api for Sql Server.</Description>
@@ -11,36 +11,40 @@
     <PackageProjectUrl>https://github.com/cajuncoding/GraphQL.RepoDb</PackageProjectUrl>
     <RepositoryUrl>https://github.com/cajuncoding/GraphQL.RepoDb</RepositoryUrl>
     <PackageTags>graphql, graph-ql, hotchocolate, azure, repository, service, repodb, dapper, petapoco, sqlkata, sorting, paging, cursor</PackageTags>
-    <PackageReleaseNotes>- Upgraded to now support HotChocolate version 12 with v12.0.1 and synced Nuget Version
+    <PackageReleaseNotes>Release Notes:
+	    - Updated to latest version of HC v12.4.1
+        - Updated Demo projects to .Net 6.0 and Azure Functions v4.
+		- Bump RepoDB (Sql Server) version to v1.1.4 stable
 
-      Prior Releases Notes:
-      - Bump HotChocolate version to v11.3.8 (latest v11 version before jumping to v12) and synced Nuget Version
-      - Added support for raw sql where filtering with Parameterization for complex where filtering and field processing (e.g. LOWER(), TRIM() functions on fields, or Full Text Search via CONTAINS(), FREETEXT(), etc.).
-      - Fix bug with TotalCount not returning when pagination or other filtering returns no results.
-      - Potential Breaking Change: Fixed method signatures to all consistently support specifying table name; this might potentially have some breaking changes to method signatures, but functionality is compatible once signatures are corrected.
-      - Provide RepoDb extension meethod QueryBulkResultsByIdAsync() which enalbes high performance retrieval of very large result sets in bulk based on int Id values; this safely alleviates the limitation of max 2100 parameter bindings on SqlCmd when using Contains() expressions.
-      - Breaking change but simplified the RepoDB Custom extension methods for CursorPaging and OffsetPaging to take in IRepoDbCursorPagingParams and IRepoDbOffsetPagingParams respectively instead of discrete values.
-      - This helps minimizes the risk of the issue arising from the Optimization to not rely on TotalCount; it introduced a non-intuitive breaking change in the ReboDB Custom extensions whereby the new 'IsTotalCountRequested' param from the GraphQLParamsContext must be explicitly provided.
-      - This also makes future enhancements easier and the method signatures more maintainable going forward.
-      - Also need to highlight another potential issue from the code optimization: Now the Cursor and Offset paging arguments are fully optional and both will default with consistent behavior to retrieve all data.
-      - Therefore Any enforcement to require paging args or limit the data if they are not provided must now be done by the consuming code; this helps the library be less opinionated and flexible but may now open prior uses to selecting more data than intended; this may be improved with configuration value in a future release.
-      - Bugfix where Count could be incorrect due to potential null values skipped by Sql Server Count() aggregation over specific field vs '*'.
-      - Bump HotChocolate version to v11.2.2 stable and sync Nuget version.
-      - Bump RepoDB (Sql Server) version to v1.1.3 stable
-      - Optimized paging algorithm to eliminate the dependency on TotalCount for computing HasPreviousPage/HasNextPage paging metadata.
-      - Optimized TotalCount query to now only be executed when requested (e.g. User requests totalCount in the GraphQL query).
-      - Add full RepoDB support for OffsetPaging (e.g. using Skip/Take instead of Batch Query (Page Size/Page Number).
-      - Some code cleanup and optimizations.
-      - Sync version with the latest Pre-processing Extensions.
-      - Add support (and fix consistency) with CommandTimeout for all query methods.
-      - Add .ConfigureAwait(false) to all awaits for performance.
-      - Bump version to HotChocolate v11.0.4.
-      - Bump to HotChocolate v11.0.2 and sync with PreProcessingExtensions issue fix release.
-      - Bump to HotChocolate v11.0.1 which now resolves a bug that we helped identify with interfaces in the initial release of v11.0.0.
-      - Fix issue with Sort/OrderBy field not working if not also part of Selection. OffsetPaging is not working, it's still work in progress. But this release provides ability to trace log out some details for the query, execution time, etc. Also improves support for cancellation token throughout DB calls and minor optimizations and cleanup.
-</PackageReleaseNotes>
-    <AssemblyVersion>12.0.1.0</AssemblyVersion>
-    <FileVersion>12.0.1.0</FileVersion>
+		Prior Releases Notes:
+		- Upgraded to now support HotChocolate version 12 with v12.0.1 and synced Nuget Version
+		- Bump HotChocolate version to v11.3.8 (latest v11 version before jumping to v12) and synced Nuget Version
+		- Added support for raw sql where filtering with Parameterization for complex where filtering and field processing (e.g. LOWER(), TRIM() functions on fields, or Full Text Search via CONTAINS(), FREETEXT(), etc.).
+		- Fix bug with TotalCount not returning when pagination or other filtering returns no results.
+		- Potential Breaking Change: Fixed method signatures to all consistently support specifying table name; this might potentially have some breaking changes to method signatures, but functionality is compatible once signatures are corrected.
+		- Provide RepoDb extension meethod QueryBulkResultsByIdAsync() which enalbes high performance retrieval of very large result sets in bulk based on int Id values; this safely alleviates the limitation of max 2100 parameter bindings on SqlCmd when using Contains() expressions.
+		- Breaking change but simplified the RepoDB Custom extension methods for CursorPaging and OffsetPaging to take in IRepoDbCursorPagingParams and IRepoDbOffsetPagingParams respectively instead of discrete values.
+		- This helps minimizes the risk of the issue arising from the Optimization to not rely on TotalCount; it introduced a non-intuitive breaking change in the ReboDB Custom extensions whereby the new 'IsTotalCountRequested' param from the GraphQLParamsContext must be explicitly provided.
+		- This also makes future enhancements easier and the method signatures more maintainable going forward.
+		- Also need to highlight another potential issue from the code optimization: Now the Cursor and Offset paging arguments are fully optional and both will default with consistent behavior to retrieve all data.
+		- Therefore Any enforcement to require paging args or limit the data if they are not provided must now be done by the consuming code; this helps the library be less opinionated and flexible but may now open prior uses to selecting more data than intended; this may be improved with configuration value in a future release.
+		- Bugfix where Count could be incorrect due to potential null values skipped by Sql Server Count() aggregation over specific field vs '*'.
+		- Bump HotChocolate version to v11.2.2 stable and sync Nuget version.
+		- Bump RepoDB (Sql Server) version to v1.1.3 stable
+		- Optimized paging algorithm to eliminate the dependency on TotalCount for computing HasPreviousPage/HasNextPage paging metadata.
+		- Optimized TotalCount query to now only be executed when requested (e.g. User requests totalCount in the GraphQL query).
+		- Add full RepoDB support for OffsetPaging (e.g. using Skip/Take instead of Batch Query (Page Size/Page Number).
+		- Some code cleanup and optimizations.
+		- Sync version with the latest Pre-processing Extensions.
+		- Add support (and fix consistency) with CommandTimeout for all query methods.
+		- Add .ConfigureAwait(false) to all awaits for performance.
+		- Bump version to HotChocolate v11.0.4.
+		- Bump to HotChocolate v11.0.2 and sync with PreProcessingExtensions issue fix release.
+		- Bump to HotChocolate v11.0.1 which now resolves a bug that we helped identify with interfaces in the initial release of v11.0.0.
+		- Fix issue with Sort/OrderBy field not working if not also part of Selection. OffsetPaging is not working, it's still work in progress. But this release provides ability to trace log out some details for the query, execution time, etc. Also improves support for cancellation token throughout DB calls and minor optimizations and cleanup.
+	</PackageReleaseNotes>
+    <AssemblyVersion>12.1.4.0</AssemblyVersion>
+    <FileVersion>12.1.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GraphQL.RepoDb.SqlServer/RepoDb.OffsetPagination/RepoDbBatchSkipTakeQueryExtensions.cs
+++ b/GraphQL.RepoDb.SqlServer/RepoDb.OffsetPagination/RepoDbBatchSkipTakeQueryExtensions.cs
@@ -219,7 +219,7 @@ namespace RepoDb.OffsetPagination
         }
 
         /// <summary>
-        /// Base Repository extension for Offset Paginated Batch Query capability.
+        /// Base DbConnection (SqlConnection) extension for Offset Paginated Batch Query capability.
         /// 
         /// Public Facade method to provide dynamically paginated results using Offset based paging/slicing.
         /// 
@@ -285,7 +285,7 @@ namespace RepoDb.OffsetPagination
         }
 
         /// <summary>
-        /// Base Repository extension for Offset Paginated Batch Query capability.
+        /// Base DbConnection (SqlConnection) extension for Offset Paginated Batch Query capability.
         /// 
         /// Public Facade method to provide dynamically paginated results using Offset based paging/slicing.
         /// 
@@ -351,7 +351,7 @@ namespace RepoDb.OffsetPagination
         }
 
         /// <summary>
-        /// Base Repository extension for Offset Paginated Batch Query capability.
+        /// Base DbConnection (SqlConnection) extension for Offset Paginated Batch Query capability.
         /// 
         /// Public Facade method to provide dynamically paginated results using Offset based paging/slicing.
         /// 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿## Overview 
-*(Unofficial) HotChocolate v11 Extension Pack for working with Micro-ORM(s) and encapsulated data access (instead of IQueryable).*
+*(Unofficial) HotChocolate v11/v12 Extension Pack for working with Micro-ORM(s) and encapsulated data access (instead of IQueryable).*
 
 This library greatly simplifies working with HotChocolate to **_pre-processes_** data for
 selecting/projecting, sorting, paging, etc. before returning the data to HotChocolate from the resolver; 
@@ -60,11 +60,13 @@ cursor pagination/slice query api for Sql Server.
 To use this in your project, add the [GraphQL.RepDb.SqlServer](https://www.nuget.org/packages/GraphQL.RepoDb.SqlServer/) 
 NuGet package to your project, wire up your Starup middleware, and inject / instantiate params in your resolvers as outlined below...
 
+### Release Notes v12.4.1.0:
+- Updated to latest version of HC v12.4.1 stable
+- Fixed breaking change in HC where Field Definition context data methods were removed; now uses the new pattern that HC Core attributes (e.g. UsePaging, UseSorting).
+- Updated Demo projects to .Net 6.0 and Azure Functions v4.
+- Bump RepoDB (Sql Server) version to v1.1.4 stable
 
-### Pending:
-1. TODO: Update Implementation summary detais below in README...
-
-### Completed:
+### Prior Release Notes:
 1. Added full support for Offset Paging with RepoDB.
 1. Optimized the RepoDB extensions Cursor paging algorithm to no longer require the TotalCount to safely determine HasNextPage & HasPreviousPage paging metadata; this helps optimize both Cursor Paging and Offset paging queries.
 1. Added RepoDB support for of the new GraphQLParamsContext.IsTotalCountRequested property so that we now only compute the Count when actually requested.

--- a/README.md
+++ b/README.md
@@ -319,19 +319,16 @@ public class HumanType : ObjectType<Human>
         descriptor.Name("human");
         descriptor.Field(t => t.Name).Type<NonNullType<StringType>>();
         descriptor.Field(t => t.Friends).Name("friends")
-            .ConfigureContextData(d =>
-            {
-                //Manually define a Selection/Projection dependency on the "Id" field of
-                //  the parent entity so that it is always provided to the parent resolver.
-                //This helps ensure that the value is not null in our resolver anytime "friends"
-                //  is part of the selection, and the parent "Id" field is not.
-                d.AddPreProcessingParentProjectionDependencies(nameof(Human.Id));
-            })
+            //Manually define a Selection/Projection dependency on the "Id" field of
+            //  the parent entity so that it is always provided to the parent resolver.
+            //This helps ensure that the value is not null in our resolver anytime "friends"
+            //  is part of the selection, and the parent "Id" field is not.
+            .AddPreProcessingParentProjectionDependencies(nameof(Human.Id))
             .Resolver(ctx =>
             {
                 var repository = ctx.Service<IRepository>();
                 var parentHumanId = ctx.Parent<Human>().Id;
-                return repository.GetHuman();
+                return repository.GetRelatedHumans(parentHumanId);
             });
     }
 }

--- a/Sample.StarWars-AzureFunctions-RepoDB/StarWars-AzureFunctions-RepoDB.csproj
+++ b/Sample.StarWars-AzureFunctions-RepoDB/StarWars-AzureFunctions-RepoDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <RootNamespace>StarWars_AzureFunctions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/Sample.StarWars-AzureFunctions-RepoDB/StarWars-AzureFunctions-RepoDB.csproj
+++ b/Sample.StarWars-AzureFunctions-RepoDB/StarWars-AzureFunctions-RepoDB.csproj
@@ -13,9 +13,9 @@
     <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GraphQL.AzureFunctionsProxy" Version="12.0.0.1" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="12.0.1" />
-    <PackageReference Include="HotChocolate.Data" Version="12.0.1" />
+    <PackageReference Include="GraphQL.AzureFunctionsProxy" Version="12.4.1" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.4.1" />
+    <PackageReference Include="HotChocolate.Data" Version="12.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="RepoDb.SqlServer" Version="1.1.4" />

--- a/Sample.StarWars-AzureFunctions/Characters/Human.cs
+++ b/Sample.StarWars-AzureFunctions/Characters/Human.cs
@@ -2,6 +2,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using HotChocolate.PreProcessingExtensions;
 using HotChocolate.Types;
 using HotChocolate.Types.Relay;
 

--- a/Sample.StarWars-AzureFunctions/StarWars-AzureFunctions.csproj
+++ b/Sample.StarWars-AzureFunctions/StarWars-AzureFunctions.csproj
@@ -8,9 +8,9 @@
     <None Include="..\README.md" Link="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GraphQL.AzureFunctionsProxy" Version="12.0.0.1" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="12.0.1" />
-    <PackageReference Include="HotChocolate.Data" Version="12.0.1" />
+    <PackageReference Include="GraphQL.AzureFunctionsProxy" Version="12.4.1" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.4.1" />
+    <PackageReference Include="HotChocolate.Data" Version="12.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
   </ItemGroup>

--- a/Sample.StarWars-AzureFunctions/StarWars-AzureFunctions.csproj
+++ b/Sample.StarWars-AzureFunctions/StarWars-AzureFunctions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <RootNamespace>StarWars_AzureFunctions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes to Unit Tests and testing of all updates. Bump version to publish to Nuget with release notes.
Release Notes:
- Updated to latest version of HC v12.4.1 stable
- Fixed breaking change in HC where Field Definition context data methods were removed; now uses the new pattern that HC Core attributes (e.g. UsePaging, UseSorting).
- Updated Demo projects to .Net 6.0 and Azure Functions v4.
- Bump RepoDB (Sql Server) version to v1.1.4 stable
